### PR TITLE
Set minimum nori and rspec versions.  Updated for HTTPS

### DIFF
--- a/lib/rx_nav.rb
+++ b/lib/rx_nav.rb
@@ -20,7 +20,7 @@ module RxNav
 
   def self.make_request query
     encoded_query = URI.encode(query)
-    request = URI.parse('https://rxnav.nlm.nih.gov/REST' + encoded_query)
+    request = URI.parse("https://rxnav.nlm.nih.gov/REST#{encoded_query}")
     return RxNav.nori.parse(Net::HTTP.get request)
   end
 

--- a/lib/rx_nav.rb
+++ b/lib/rx_nav.rb
@@ -20,7 +20,7 @@ module RxNav
 
   def self.make_request query
     encoded_query = URI.encode(query)
-    request = URI.parse('http://rxnav.nlm.nih.gov/REST' + encoded_query)
+    request = URI.parse('https://rxnav.nlm.nih.gov/REST' + encoded_query)
     return RxNav.nori.parse(Net::HTTP.get request)
   end
 

--- a/rx_nav.gemspec
+++ b/rx_nav.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nori'
+  spec.add_dependency 'nori', '>= 2.0.0'
   spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '>= 2.0.0'
+  spec.add_development_dependency 'rspec', '>= 3.0.0'
 end

--- a/spec/rx_nav_spec.rb
+++ b/spec/rx_nav_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe "http://rxnav.nlm.nih.gov/REST" do
+describe "https://rxnav.nlm.nih.gov/REST" do
   before :all do
-    @url      = URI "http://rxnav.nlm.nih.gov/REST/json"
+    @url      = URI "https://rxnav.nlm.nih.gov/REST/json"
     @response = Net::HTTP.get(@url)
     @json     = JSON.parse(@response)
   end

--- a/spec/rx_norm_spec.rb
+++ b/spec/rx_norm_spec.rb
@@ -17,7 +17,7 @@ describe RxNav::RxNorm do
       "#{url}/spellingsuggestions?name=yourName",
       "#{url}/rxcui/{rxcui}/status",
       "#{url}/rxcui/{rxcui}/properties",
-      "#{url}/rxcui/{rxcui}/property?propName=propName",
+      "#{url}/rxcui/{rxcui}/property?propName=propName"
     ]
   end
 

--- a/spec/rx_norm_spec.rb
+++ b/spec/rx_norm_spec.rb
@@ -5,7 +5,7 @@ require 'support/array_type'
 describe RxNav::RxNorm do
 
   describe "remote endpoints" do
-    url      = "http://rxnav.nlm.nih.gov/REST"
+    url      = "https://rxnav.nlm.nih.gov/REST"
     response = Net::HTTP.get(URI("#{url}/json"))
     subject  { JSON.parse(response)["resourceList"]["resource"] }
 
@@ -17,7 +17,7 @@ describe RxNav::RxNorm do
       "#{url}/spellingsuggestions?name=yourName",
       "#{url}/rxcui/{rxcui}/status",
       "#{url}/rxcui/{rxcui}/properties",
-      "#{url}/rxcui/{rxcui}/property?propName=propName"
+      "#{url}/rxcui/{rxcui}/property?propName=propName",
     ]
   end
 


### PR DESCRIPTION
Specs were failing due to https endpoints returned from https://rxnav.nlm.nih.gov/REST/json

NDFRT lists endpoints as http, but they respond to https as well: http://rxnav.nlm.nih.gov/REST/Ndfrt/json
